### PR TITLE
Fix Vercel output directory path

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
   "buildCommand": "npm run build --workspace=@gencv/web",
-  "outputDirectory": "apps/web/.next",
+  "outputDirectory": ".next",
   "installCommand": "npm install",
   "functions": {
     "apps/web/app/api/generate-pdf/route.ts": {


### PR DESCRIPTION
## Summary
- correct Vercel `outputDirectory` to avoid double `apps/web` prefix and missing routes manifest

## Testing
- `npm run test:backend`
- `npm run test:api` *(fails: Server health check failed: fetch failed)*
- `npm run build --workspace=@gencv/web` *(fails: Failed to fetch font `Inter`)*

------
https://chatgpt.com/codex/tasks/task_e_68c5a0a79b808326af6713e05bb0a7d4