### PR TITLE
Enable configurable CORS for API routes

### DIFF
--- a/apps/web/app/api/ai/route.ts
+++ b/apps/web/app/api/ai/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { ContentEnhancer } from '@gencv/lib-ai';
+import { getCorsHeaders } from '@/lib/cors';
 
 export const maxDuration = 60; // 60 seconds timeout
 export const runtime = 'nodejs'; // Gunakan runtime nodejs untuk memastikan SDK Google berfungsi dengan benar
@@ -71,4 +72,9 @@ export async function POST(request: NextRequest) {
       { status: 500 }
     );
   }
+}
+
+export function OPTIONS(request: NextRequest) {
+  const headers = getCorsHeaders(request);
+  return NextResponse.json({}, { headers });
 }

--- a/apps/web/app/api/generate-pdf/route.ts
+++ b/apps/web/app/api/generate-pdf/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { CVData, CVTemplate } from '@gencv/types';
 import { generatePDF } from '@/app/actions/pdf-generator';
+import { getCorsHeaders } from '@/lib/cors';
 
 // Konfigurasi khusus untuk endpoint PDF
 export const runtime = 'nodejs'; // Memastikan kompatibilitas dengan Puppeteer
@@ -82,4 +83,9 @@ export async function POST(request: NextRequest) {
       { status: 500, headers: { 'Content-Type': 'application/json' } }
     );
   }
+}
+
+export function OPTIONS(request: NextRequest) {
+  const headers = getCorsHeaders(request);
+  return NextResponse.json({}, { headers });
 }

--- a/apps/web/lib/cors.ts
+++ b/apps/web/lib/cors.ts
@@ -1,0 +1,24 @@
+import { NextRequest } from 'next/server';
+
+export function getCorsHeaders(request: NextRequest) {
+  const origin = request.headers.get('origin') || '';
+  const allowedEnv = process.env.ALLOWED_ORIGINS || process.env.FRONTEND_URL || '';
+
+  let allowOrigin = '*';
+  if (allowedEnv) {
+    const allowed = allowedEnv.split(',').map(o => o.trim());
+    if (origin && allowed.includes(origin)) {
+      allowOrigin = origin;
+    } else {
+      allowOrigin = allowed[0];
+    }
+  } else if (origin) {
+    allowOrigin = origin;
+  }
+
+  return {
+    'Access-Control-Allow-Origin': allowOrigin,
+    'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type, Authorization, x-api-key'
+  } as Record<string, string>;
+}

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { getCorsHeaders } from './lib/cors';
 
 // Simple in-memory rate limiter
 const rateLimiter = new Map<string, { count: number; resetTime: number }>();
@@ -74,9 +75,10 @@ export async function middleware(request: NextRequest) {
   
   // Add CORS headers for API routes
   if (pathname.startsWith('/api/')) {
-    response.headers.set('Access-Control-Allow-Origin', process.env.FRONTEND_URL || '*');
-    response.headers.set('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
-    response.headers.set('Access-Control-Allow-Headers', 'Content-Type, Authorization, x-api-key');
+    const cors = getCorsHeaders(request);
+    Object.entries(cors).forEach(([key, value]) => {
+      response.headers.set(key, value);
+    });
   }
   
   return response;


### PR DESCRIPTION
## Summary
- Add reusable `getCorsHeaders` helper for dynamic origin checking
- Apply CORS headers in middleware and provide OPTIONS handlers for API routes

## Testing
- `npm run test:full` *(fails: Server is not responding. Please start the server first)*

------
https://chatgpt.com/codex/tasks/task_e_68c5a41693748326a540c94ba0d4f384